### PR TITLE
feat: DFXML 추출 버튼 추가 (전체 + 노드별)

### DIFF
--- a/src/components/ForensicApp.tsx
+++ b/src/components/ForensicApp.tsx
@@ -108,6 +108,10 @@ export default function ForensicApp() {
     () => reportRun.downloadReport(activeCase, submittedPrompt),
     [reportRun, activeCase, submittedPrompt]
   );
+  const handleDownloadDfxml = useCallback(
+    () => reportRun.downloadDfxml(activeCase),
+    [reportRun, activeCase]
+  );
 
   const handleSelectNode = useCallback((idx: number) => {
     setSelectedNode(prev => prev === idx ? null : idx);
@@ -183,6 +187,7 @@ export default function ForensicApp() {
     onApproveReport: handleApproveReport,
     onOpenMcpModal: openMcpModal,
     onDownloadReport: handleDownloadReport,
+    onDownloadDfxml: handleDownloadDfxml,
     onEvidenceFilePick: e => {
       const file = e.target.files?.[0];
       if (file) setAttachedFile({ name: file.name });
@@ -308,6 +313,7 @@ export default function ForensicApp() {
                   onSelectNode={handleSelectNode}
                   onEdgeClick={setSelectedEdge}
                   dfxmlFragments={workflow.nodeDfxmlFragments}
+                  caseTitle={activeCase.title}
                 />
               ) : (
                 <div className="absolute inset-0 flex items-center justify-center">

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -39,10 +39,11 @@ interface Props {
   onSelectNode: (idx: number) => void;
   onEdgeClick: (edge: SelectedEdge) => void;
   dfxmlFragments?: Record<number, string>;
+  caseTitle?: string;
 }
 
 export default function WorkflowCanvas({
-  editablePlan, workflowState, activeStep, selectedNode, onSelectNode, onEdgeClick, dfxmlFragments,
+  editablePlan, workflowState, activeStep, selectedNode, onSelectNode, onEdgeClick, dfxmlFragments, caseTitle,
 }: Props) {
   const getNodeStatus = useCallback(
     (i: number): WorkflowNodeData['nodeStatus'] => {
@@ -62,9 +63,10 @@ export default function WorkflowCanvas({
       nodeIdx: i,
       isSelected: selectedNode === i,
       dfxml: { name: item.name, xml: dfxmlFragments?.[i] ?? '' },
+      caseTitle: caseTitle ?? '',
       onSelect: onSelectNode,
     }),
-    [getNodeStatus, selectedNode, onSelectNode, dfxmlFragments]
+    [getNodeStatus, selectedNode, onSelectNode, dfxmlFragments, caseTitle]
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState<WorkflowNodeType>([]);

--- a/src/components/nodes/WorkflowNode.tsx
+++ b/src/components/nodes/WorkflowNode.tsx
@@ -3,8 +3,9 @@
 import { useState, useCallback, useRef } from 'react';
 import { Handle, Position, NodeToolbar } from '@xyflow/react';
 import type { NodeProps, Node } from '@xyflow/react';
-import { X, GripVertical } from 'lucide-react';
+import { X, GripVertical, Download } from 'lucide-react';
 import type { WorkflowNodeData } from '@/types';
+import { downloadTextFile, sanitizeFilename } from '@/lib/utils';
 
 export type WorkflowNodeType = Node<WorkflowNodeData, 'workflowNode'>;
 
@@ -41,9 +42,30 @@ const MIN_H = 300;
 const DEFAULT_W = 480;
 const DEFAULT_H = 440;
 
-function DFXMLPanel({ dfxml, onClose }: { dfxml: WorkflowNodeData['dfxml']; onClose: () => void }) {
+function DFXMLPanel({
+  dfxml, nodeIdx, tool, caseTitle, onClose,
+}: {
+  dfxml: WorkflowNodeData['dfxml'];
+  nodeIdx: number;
+  tool: string;
+  caseTitle: string;
+  onClose: () => void;
+}) {
   const [size, setSize] = useState({ w: DEFAULT_W, h: DEFAULT_H });
   const dragRef = useRef<{ startX: number; startY: number; startW: number; startH: number } | null>(null);
+
+  const canDownload = Boolean(dfxml.xml);
+  const handleDownload = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!canDownload) return;
+    const slug = sanitizeFilename(caseTitle || 'case');
+    const toolSlug = sanitizeFilename(tool || 'step');
+    downloadTextFile(
+      `${slug}_step${nodeIdx + 1}_${toolSlug}_dfxml.xml`,
+      dfxml.xml,
+      'application/xml;charset=utf-8',
+    );
+  }, [canDownload, caseTitle, dfxml.xml, nodeIdx, tool]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -79,13 +101,28 @@ function DFXMLPanel({ dfxml, onClose }: { dfxml: WorkflowNodeData['dfxml']; onCl
           <span className="text-[11px] font-bold text-sky-400 tracking-wider">DFXML</span>
           <span className="text-[10px] text-slate-500">{dfxml.name}</span>
         </div>
-        <button
-          onMouseDown={e => e.stopPropagation()}
-          onClick={e => { e.stopPropagation(); onClose(); }}
-          className="w-5 h-5 flex items-center justify-center text-slate-500 hover:text-slate-200 hover:bg-slate-700 rounded border-none bg-transparent cursor-pointer p-0 transition-colors"
-        >
-          <X size={13} />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onMouseDown={e => e.stopPropagation()}
+            onClick={handleDownload}
+            disabled={!canDownload}
+            aria-label="DFXML 추출"
+            title={canDownload ? 'DFXML 추출' : 'DFXML 데이터 없음'}
+            className="h-5 px-1.5 flex items-center gap-1 text-[10px] text-slate-300 hover:text-sky-300 hover:bg-slate-700 rounded border-none bg-transparent cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-slate-300 disabled:hover:bg-transparent"
+          >
+            <Download size={11} />
+            <span>추출</span>
+          </button>
+          <button
+            onMouseDown={e => e.stopPropagation()}
+            onClick={e => { e.stopPropagation(); onClose(); }}
+            aria-label="DFXML 패널 닫기"
+            className="w-5 h-5 flex items-center justify-center text-slate-500 hover:text-slate-200 hover:bg-slate-700 rounded border-none bg-transparent cursor-pointer p-0 transition-colors"
+          >
+            <X size={13} />
+          </button>
+        </div>
       </div>
 
       {/* Content */}
@@ -105,7 +142,7 @@ function DFXMLPanel({ dfxml, onClose }: { dfxml: WorkflowNodeData['dfxml']; onCl
 }
 
 export default function WorkflowNode({ data }: NodeProps<WorkflowNodeType>) {
-  const { title, tool, nodeStatus, nodeIdx, isSelected, dfxml, onSelect } = data;
+  const { title, tool, nodeStatus, nodeIdx, isSelected, dfxml, caseTitle, onSelect } = data;
 
   const statusStyles = {
     approved: { dot: 'bg-amber-500', border: 'border-amber-500 border-dashed', badgeBg: 'bg-amber-50 text-amber-600', label: '승인됨' },
@@ -142,7 +179,13 @@ export default function WorkflowNode({ data }: NodeProps<WorkflowNodeType>) {
       {/* NodeToolbar: 노드 외부에 렌더링되어 노드 크기·핸들에 영향 없음 */}
       {dfxml && (
         <NodeToolbar isVisible={isSelected} position={Position.Bottom} offset={8}>
-          <DFXMLPanel dfxml={dfxml} onClose={() => onSelect(nodeIdx)} />
+          <DFXMLPanel
+            dfxml={dfxml}
+            nodeIdx={nodeIdx}
+            tool={tool}
+            caseTitle={caseTitle}
+            onClose={() => onSelect(nodeIdx)}
+          />
         </NodeToolbar>
       )}
     </div>

--- a/src/components/panels/DoneSummaryPanel.tsx
+++ b/src/components/panels/DoneSummaryPanel.tsx
@@ -11,7 +11,7 @@ export default function DoneSummaryPanel() {
     diskImagePath, diskImageCheck,
     taskResults, elapsedTime,
     reportState, setShowReportViewer,
-    onApproveReport, onDownloadReport,
+    onApproveReport, onDownloadReport, onDownloadDfxml,
   } = useWorkflowContext();
 
   if (workflowState !== 'done') return null;
@@ -177,6 +177,15 @@ export default function DoneSummaryPanel() {
                 <Download size={12} /> 보고서 다운로드
               </button>
             </div>
+            <button
+              type="button"
+              onClick={onDownloadDfxml}
+              disabled={!onDownloadDfxml}
+              aria-label="DFXML 다운로드"
+              className="h-[30px] bg-f-surface2 border border-f-border2 rounded text-f-t2 text-[11px] font-medium cursor-pointer flex items-center justify-center gap-1 hover:bg-f-border transition-colors disabled:opacity-50 disabled:cursor-default"
+            >
+              <Download size={12} /> DFXML 다운로드
+            </button>
           </div>
         </div>
       )}

--- a/src/contexts/WorkflowContext.tsx
+++ b/src/contexts/WorkflowContext.tsx
@@ -65,6 +65,7 @@ export interface WorkflowContextValue {
   onApproveReport: () => void;
   onOpenMcpModal: (idx: number) => void;
   onDownloadReport?: () => void;
+  onDownloadDfxml?: () => void;
   onEvidenceFilePick: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 

--- a/src/hooks/useReportRun.ts
+++ b/src/hooks/useReportRun.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { api } from '@/lib/api';
+import { downloadTextFile, sanitizeFilename } from '@/lib/utils';
 import type { ActiveCase, ReportState } from '@/types';
 
 export interface TaskResult {
@@ -75,15 +76,18 @@ export function useReportRun() {
       if (reportData?.report) {
         lines.push(`${reportData.summary ? '3' : '2'}. 상세 보고서`, '-'.repeat(30), reportData.report);
       }
-      const blob = new Blob([lines.join('\n')], { type: 'text/plain;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${activeCase.id}_forensic_report.txt`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadTextFile(`${activeCase.id}_forensic_report.txt`, lines.join('\n'));
+    },
+    [reportData]
+  );
+
+  const downloadDfxml = useCallback(
+    (activeCase: ActiveCase) => {
+      const xml = reportData?.dfxml;
+      if (!xml) return;
+      const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+      const slug = sanitizeFilename(activeCase.title || activeCase.id);
+      downloadTextFile(`${slug}_${date}_dfxml.xml`, xml, 'application/xml;charset=utf-8');
     },
     [reportData]
   );
@@ -109,6 +113,7 @@ export function useReportRun() {
     handleReportReady,
     approveReport,
     downloadReport,
+    downloadDfxml,
     reset,
   };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -85,6 +85,26 @@ export function recommendMcpForStrategyStep(stepText: string): string {
   return 'Dissect MCP';
 }
 
+export function sanitizeFilename(input: string): string {
+  const cleaned = String(input || '')
+    .replace(/[\\/:*?"<>|]+/g, '_')
+    .replace(/\s+/g, '_')
+    .trim();
+  return cleaned || 'untitled';
+}
+
+export function downloadTextFile(filename: string, content: string, mime = 'text/plain;charset=utf-8'): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 export function nextCaseId(cases: { id: string }[]): string {
   const nums = cases.map(c => {
     const m = String(c.id).match(/DF-\d{4}-(\d+)/);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,7 @@ export interface WorkflowNodeData {
   nodeIdx: number;
   isSelected: boolean;
   dfxml: DfxmlNode;
+  caseTitle: string;
   onSelect: (idx: number) => void;
   [key: string]: unknown; // required by @xyflow/react Node<Data> constraint
 }


### PR DESCRIPTION
## Summary
- 분석 완료(report `done`) 영역에 **전체 DFXML 다운로드** 버튼 추가
- 워크플로 `DFXMLPanel` 헤더에 **노드별 fragment 추출** 버튼 추가
- DFXML은 XML 스키마이므로 확장자는 `.xml`로 통일하고 파일명에 `_dfxml` 토큰 포함
- 다운로드 유틸을 `lib/utils`의 `downloadTextFile` / `sanitizeFilename` 공용 헬퍼로 분리

## File naming
- 전체: `{caseTitle}_{YYYYMMDD}_dfxml.xml`
- 노드별: `{caseTitle}_step{n}_{tool}_dfxml.xml`

## Test plan
- [ ] `npm run build` 0 오류
- [ ] 분석 완료 → 보고서 생성 → "DFXML 다운로드" 클릭 시 파일 저장 확인
- [ ] 워크플로 노드 선택 → DFXMLPanel "추출" 버튼 클릭 시 fragment 저장 확인
- [ ] DFXML 비어있는 노드/리포트 미생성 상태에서 버튼 disabled 확인
- [ ] 다운로드된 `.xml` 파일이 브라우저/에디터에서 정상 열림 확인

Closes #14