### PR TITLE
style: 케이스 목록 UI 미니멀 정리 및 Case 타입 정리

### DIFF
--- a/src/components/CaseListView.tsx
+++ b/src/components/CaseListView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useEffect } from 'react';
-import { Check, ChevronDown, Trash2 } from 'lucide-react';
+import { Check, ChevronDown, Trash2, FolderOpen, Search } from 'lucide-react';
 import type { Case, CaseSort, ActiveCase } from '@/types';
 
 interface Props {
@@ -19,42 +19,71 @@ interface Props {
 }
 
 const SORT_LABEL: Record<string, string> = {
-  dateDesc: '최신순', dateAsc: '오래된순', titleAsc: '제목 (가나다)',
+  dateDesc: '최신순',
+  dateAsc: '오래된순',
+  titleAsc: '제목순',
 };
 
+/** 케이스 ID에서 숫자 시퀀스만 추출 (예: DF-2026-0425 → 0425) */
+function shortSeq(id: string): string {
+  const parts = id.split('-');
+  return parts[parts.length - 1] ?? id;
+}
+
+/** ISO 날짜를 'YY.MM.DD' 형식으로 압축 */
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const yy = String(d.getFullYear()).slice(2);
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yy}.${mm}.${dd}`;
+}
+
 export default function CaseListView({
-  cases, caseSearchQuery, setCaseSearchQuery,
-  caseAnalystFilter, setCaseAnalystFilter,
-  caseSort, setCaseSort,
-  caseFilterMenu, setCaseFilterMenu,
-  onRowClick, onDelete,
+  cases,
+  caseSearchQuery,
+  setCaseSearchQuery,
+  caseAnalystFilter,
+  setCaseAnalystFilter,
+  caseSort,
+  setCaseSort,
+  caseFilterMenu,
+  setCaseFilterMenu,
+  onRowClick,
+  onDelete,
 }: Props) {
+  /* ── 파생 데이터 ── */
   const uniqueAnalysts = useMemo(
-    () => [...new Set(cases.map(c => c.analyst))].sort((a, b) => a.localeCompare(b, 'ko')),
+    () =>
+      [...new Set(cases.map((c) => c.analyst))].sort((a, b) =>
+        a.localeCompare(b, 'ko')
+      ),
     [cases]
   );
 
-  const recentCase = useMemo(() => {
-    const sorted = [...cases].sort((a, b) => {
-      const da = new Date(a.date).getTime() || 0;
-      const db = new Date(b.date).getTime() || 0;
-      return db - da;
-    });
-    return sorted[0] ?? null;
+  const recentDate = useMemo(() => {
+    const ts = cases
+      .map((c) => new Date(c.date).getTime())
+      .filter((n) => Number.isFinite(n) && n > 0);
+    if (ts.length === 0) return null;
+    return new Date(Math.max(...ts)).toISOString().slice(0, 10);
   }, [cases]);
 
   const filteredCases = useMemo(() => {
     let list = [...cases];
     const q = caseSearchQuery.trim().toLowerCase();
     if (q) {
-      list = list.filter(c =>
-        String(c.id).toLowerCase().includes(q) ||
-        String(c.title).toLowerCase().includes(q) ||
-        String(c.analyst).toLowerCase().includes(q) ||
-        String(c.size || '').toLowerCase().includes(q)
+      list = list.filter(
+        (c) =>
+          String(c.id).toLowerCase().includes(q) ||
+          String(c.title).toLowerCase().includes(q) ||
+          String(c.analyst).toLowerCase().includes(q) ||
+          String(c.size || '').toLowerCase().includes(q)
       );
     }
-    if (caseAnalystFilter !== 'all') list = list.filter(c => c.analyst === caseAnalystFilter);
+    if (caseAnalystFilter !== 'all')
+      list = list.filter((c) => c.analyst === caseAnalystFilter);
     list.sort((a, b) => {
       if (caseSort === 'titleAsc') return a.title.localeCompare(b.title, 'ko');
       const da = new Date(a.date).getTime() || 0;
@@ -64,204 +93,345 @@ export default function CaseListView({
     return list;
   }, [cases, caseSearchQuery, caseAnalystFilter, caseSort]);
 
+  /* ── 외부 클릭 시 메뉴 닫기 ── */
   useEffect(() => {
     if (!caseFilterMenu) return;
     const onDown = (e: MouseEvent) => {
-      if (!(e.target as Element).closest?.('[data-case-filter-root]')) setCaseFilterMenu(null);
+      if (!(e.target as Element).closest?.('[data-case-filter-root]'))
+        setCaseFilterMenu(null);
     };
     document.addEventListener('mousedown', onDown);
     return () => document.removeEventListener('mousedown', onDown);
   }, [caseFilterMenu, setCaseFilterMenu]);
 
-  const DropMenu = ({ menuKey, label, children }: { menuKey: string; label: string; children: React.ReactNode }) => (
+  const isFiltered = filteredCases.length !== cases.length;
+
+  /* ── 하위 컴포넌트 ── */
+  const DropMenu = ({
+    menuKey,
+    label,
+    children,
+  }: {
+    menuKey: string;
+    label: string;
+    children: React.ReactNode;
+  }) => (
     <div className="relative">
       <button
         type="button"
-        onClick={() => setCaseFilterMenu(caseFilterMenu === menuKey ? null : menuKey)}
-        className={`h-7 px-2.5 bg-f-surface border rounded-[5px] flex items-center gap-1 text-[11px] text-f-t3 cursor-pointer
-          ${caseFilterMenu === menuKey ? 'border-f-accent' : 'border-f-border'}`}
+        onClick={() =>
+          setCaseFilterMenu(caseFilterMenu === menuKey ? null : menuKey)
+        }
+        className={`h-7 px-3 bg-f-surface border rounded-md flex items-center gap-1.5 text-[11px] font-medium tracking-wide cursor-pointer transition-all
+          ${
+            caseFilterMenu === menuKey
+              ? 'border-f-accent text-f-accent shadow-[0_0_0_2px_theme(colors.f.accent-light)]'
+              : 'border-f-border text-f-t2 hover:border-f-border2 hover:text-f-t1'
+          }`}
       >
         {label}
         <ChevronDown
-          size={11}
-          style={{ transform: caseFilterMenu === menuKey ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}
+          size={10}
+          className={`transition-transform duration-150 ${
+            caseFilterMenu === menuKey ? 'rotate-180' : ''
+          }`}
         />
       </button>
       {caseFilterMenu === menuKey && (
-        <div className="absolute top-full left-0 mt-1 min-w-[168px] bg-f-surface border border-f-border rounded-md shadow-lg z-[80] py-1 max-h-60 overflow-y-auto">
+        <div className="absolute top-full left-0 mt-1.5 min-w-[160px] bg-f-surface border border-f-border rounded-lg shadow-modal z-[80] py-1 max-h-56 overflow-y-auto animate-fadeIn">
           {children}
         </div>
       )}
     </div>
   );
 
-  const Opt = ({ active, label, onPick }: { active: boolean; label: string; onPick: () => void }) => (
+  const Opt = ({
+    active,
+    label,
+    onPick,
+  }: {
+    active: boolean;
+    label: string;
+    onPick: () => void;
+  }) => (
     <button
       type="button"
-      onClick={() => { onPick(); setCaseFilterMenu(null); }}
-      className={`block w-full text-left px-3 py-2 text-xs border-none cursor-pointer
-        ${active ? 'bg-f-accent-light text-f-accent' : 'bg-transparent text-f-t2 hover:bg-f-surface2'}`}
+      onClick={() => {
+        onPick();
+        setCaseFilterMenu(null);
+      }}
+      className={`flex items-center w-full text-left px-3 py-1.5 text-[12px] border-none cursor-pointer gap-2
+        ${
+          active
+            ? 'bg-f-accent-light text-f-accent font-medium'
+            : 'bg-transparent text-f-t2 hover:bg-f-surface2'
+        }`}
     >
-      {active && <Check size={11} className="inline mr-1.5 align-middle" />}
+      <span
+        className={`w-3.5 h-3.5 flex items-center justify-center shrink-0 ${active ? '' : 'opacity-0'}`}
+      >
+        <Check size={10} />
+      </span>
       {label}
     </button>
   );
 
+  /* ── 메인 렌더 ── */
   return (
     <div className="flex-1 flex flex-col bg-f-bg overflow-hidden">
-      <div className="bg-f-surface border-b border-f-border px-4 py-3 shrink-0">
-        <div className="flex flex-wrap gap-3">
-          <div className="min-w-[360px] flex-[2_1_460px]">
-            <div className="text-[10px] font-semibold text-f-t4 tracking-wider uppercase mb-2">
-              케이스 인벤토리
-            </div>
-            <div className="grid grid-cols-3 border border-f-border rounded-md overflow-hidden bg-f-surface2">
-              <div className="min-w-0 h-[64px] px-3 py-2.5 bg-f-surface border-r border-f-border">
-                <span className="block text-[10px] text-f-t4 mb-1 whitespace-nowrap">전체 케이스</span>
-                <span className="block text-xl font-semibold text-f-accent">{cases.length}</span>
-              </div>
-              <div className="min-w-0 h-[64px] px-3 py-2.5 bg-f-surface border-r border-f-border">
-                <span className="block text-[10px] text-f-t4 mb-1 whitespace-nowrap">등록 유형</span>
-                <span className="block text-[13px] font-semibold text-f-t1 pt-1">디스크 이미지</span>
-              </div>
-              <div className="min-w-0 h-[64px] px-3 py-2.5 bg-f-surface">
-                <span className="block text-[10px] text-f-t4 mb-1 whitespace-nowrap">분석관</span>
-                <span className="block text-xl font-semibold text-f-t1">{uniqueAnalysts.length}</span>
-              </div>
-            </div>
-          </div>
 
-          <div className="min-w-[240px] flex-[1_1_260px] border border-f-border rounded-md bg-f-surface2 px-3 py-2.5">
-            <div className="text-[10px] font-semibold text-f-t4 tracking-wider uppercase mb-2">
-              분석관
-            </div>
-            {uniqueAnalysts.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5">
-                {uniqueAnalysts.map(name => (
-                  <span
-                    key={name}
-                    className="inline-flex items-center gap-1 rounded border border-f-border bg-f-surface px-2 py-1 text-[11px] text-f-t2"
-                  >
-                    {name}
+      {/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+          HERO STAT BAR
+          전체 케이스 수를 크게 노출하는 상단 배너.
+          테이블 헤더나 카드 그리드가 아닌
+          "운영 대시보드" 느낌의 단일 수평 띠.
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */}
+      <header className="bg-f-surface border-b border-f-border shrink-0 px-6 py-4">
+        <div className="flex items-end justify-between">
+          {/* 좌: 큰 숫자 + 레이블 */}
+          <div className="flex items-end gap-5">
+            <div>
+              <p className="text-[11px] font-semibold tracking-[0.12em] uppercase text-f-t4 mb-0.5">
+                케이스 인벤토리
+              </p>
+              <div className="flex items-baseline gap-2">
+                <span className="text-[40px] font-bold leading-none text-f-t1 font-mono tabular-nums">
+                  {filteredCases.length}
+                </span>
+                {isFiltered && (
+                  <span className="text-[16px] text-f-t4 font-mono">
+                    /{cases.length}
                   </span>
-                ))}
+                )}
               </div>
-            ) : (
-              <div className="text-xs text-f-t4 pt-3">등록된 분석관이 없습니다.</div>
-            )}
+            </div>
+
+            {/* 구분선 */}
+            <div className="w-px h-10 bg-f-border mb-0.5" aria-hidden />
+
+            {/* 보조 스탯 */}
+            <dl className="flex gap-5 mb-0.5">
+              {[
+                { label: '분석관', value: String(uniqueAnalysts.length) },
+                { label: '최근 갱신', value: recentDate ? fmtDate(recentDate) : '—' },
+                { label: '총 용량', value: (() => {
+                  const gb = cases.reduce((acc, c) => {
+                    const m = c.size.match(/([\d.]+)\s*(GB|MB|TB)/i);
+                    if (!m) return acc;
+                    const n = parseFloat(m[1]);
+                    const u = m[2].toUpperCase();
+                    return acc + (u === 'TB' ? n * 1024 : u === 'MB' ? n / 1024 : n);
+                  }, 0);
+                  return gb >= 1024
+                    ? `${(gb / 1024).toFixed(1)} TB`
+                    : `${gb % 1 === 0 ? gb : gb.toFixed(1)} GB`;
+                })() },
+              ].map((s) => (
+                <div key={s.label} className="flex flex-col gap-0.5">
+                  <dt className="text-[10px] text-f-t4 tracking-[0.1em] uppercase font-medium">
+                    {s.label}
+                  </dt>
+                  <dd className="text-[18px] font-semibold text-f-t2 font-mono tabular-nums leading-none">
+                    {s.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
           </div>
 
-          <div className="min-w-[220px] flex-[1_1_240px] border border-f-border rounded-md bg-f-surface2 px-3 py-2.5">
-            <div className="text-[10px] font-semibold text-f-t4 tracking-wider uppercase mb-2">
-              최근 케이스
-            </div>
-            {recentCase ? (
-              <button
-                type="button"
-                onClick={() => onRowClick({ id: recentCase.id, title: recentCase.title })}
-                className="block w-full text-left"
-              >
-                <span className="block text-[13px] font-medium text-f-t1 overflow-hidden text-ellipsis whitespace-nowrap">
-                  {recentCase.title}
-                </span>
-                <span className="flex items-center justify-between gap-2 mt-1">
-                  <span className="text-[11px] font-mono text-f-t4">{recentCase.id}</span>
-                  <span className="text-[11px] text-f-t3">{recentCase.size}</span>
-                </span>
-                <span className="block text-[11px] text-f-t4 mt-2">{recentCase.date}</span>
-              </button>
-            ) : (
-              <div className="text-xs text-f-t4 pt-3">등록된 케이스가 없습니다.</div>
-            )}
+          {/* 우: 검색 — 히어로 레벨로 배치 */}
+          <div className="relative w-80">
+            <Search
+              size={14}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-f-t4 pointer-events-none"
+            />
+            <input
+              type="search"
+              placeholder="검색 (ID · 제목 · 분석관 · 용량)"
+              value={caseSearchQuery}
+              onChange={(e) => setCaseSearchQuery(e.target.value)}
+              className="w-full h-9 bg-f-bg border border-f-border rounded-lg pl-9 pr-3 text-[13px] text-f-t1 placeholder:text-f-t4 outline-none focus:border-f-accent focus:bg-f-surface transition-colors"
+            />
           </div>
         </div>
-      </div>
+      </header>
 
+      {/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+          필터 툴바 — 히어로 아래 얇은 띠
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */}
       <div
         data-case-filter-root
-        className={`h-11 bg-f-surface border-b border-f-border flex items-center px-4 gap-2.5 shrink-0 relative ${caseFilterMenu ? 'z-40' : 'z-[1]'}`}
+        className={`bg-f-bg border-b border-f-border h-10 flex items-center px-6 gap-2 shrink-0 ${
+          caseFilterMenu ? 'z-40 relative' : 'z-[1]'
+        }`}
       >
-        <div className="relative w-72">
-          <svg
-            width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="2"
-            className="absolute left-2 top-1/2 -translate-y-1/2"
-          >
-            <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
-          </svg>
-          <input
-            type="text"
-            placeholder="케이스 검색 (ID·제목·분석관·용량)…"
-            value={caseSearchQuery}
-            onChange={e => setCaseSearchQuery(e.target.value)}
-            className="w-full h-7 bg-f-surface2 border border-f-border rounded-[5px] pl-7 pr-2 text-xs text-f-t1 outline-none focus:border-f-accent"
-          />
-        </div>
+        <span className="text-[10px] text-f-t4 tracking-[0.1em] uppercase font-medium mr-1">
+          필터
+        </span>
 
-        <DropMenu menuKey="analyst" label={`분석관: ${caseAnalystFilter === 'all' ? '전체' : caseAnalystFilter}`}>
-          <Opt active={caseAnalystFilter === 'all'} label="전체" onPick={() => setCaseAnalystFilter('all')} />
-          {uniqueAnalysts.map(name => (
-            <Opt key={name} active={caseAnalystFilter === name} label={name} onPick={() => setCaseAnalystFilter(name)} />
+        <DropMenu
+          menuKey="analyst"
+          label={
+            caseAnalystFilter === 'all' ? '분석관' : caseAnalystFilter
+          }
+        >
+          <Opt
+            active={caseAnalystFilter === 'all'}
+            label="전체"
+            onPick={() => setCaseAnalystFilter('all')}
+          />
+          {uniqueAnalysts.map((name) => (
+            <Opt
+              key={name}
+              active={caseAnalystFilter === name}
+              label={name}
+              onPick={() => setCaseAnalystFilter(name)}
+            />
           ))}
         </DropMenu>
 
-        <DropMenu menuKey="sort" label={`정렬: ${SORT_LABEL[caseSort]}`}>
-          <Opt active={caseSort === 'dateDesc'} label="최신순 (생성일)" onPick={() => setCaseSort('dateDesc')} />
-          <Opt active={caseSort === 'dateAsc'} label="오래된순 (생성일)" onPick={() => setCaseSort('dateAsc')} />
-          <Opt active={caseSort === 'titleAsc'} label="제목 (가나다)" onPick={() => setCaseSort('titleAsc')} />
+        <DropMenu menuKey="sort" label={SORT_LABEL[caseSort]}>
+          <Opt
+            active={caseSort === 'dateDesc'}
+            label="최신순"
+            onPick={() => setCaseSort('dateDesc')}
+          />
+          <Opt
+            active={caseSort === 'dateAsc'}
+            label="오래된순"
+            onPick={() => setCaseSort('dateAsc')}
+          />
+          <Opt
+            active={caseSort === 'titleAsc'}
+            label="제목순"
+            onPick={() => setCaseSort('titleAsc')}
+          />
         </DropMenu>
 
-        <div className="ml-auto text-[11px] text-f-t4">
-          {cases.length}건 중 <span className="text-f-t2 font-medium">{filteredCases.length}</span>건 표시
-        </div>
+        {(caseAnalystFilter !== 'all' || caseSearchQuery.trim()) && (
+          <button
+            type="button"
+            onClick={() => {
+              setCaseAnalystFilter('all');
+              setCaseSearchQuery('');
+            }}
+            className="ml-1 h-5 px-2 text-[10px] text-f-t3 border border-f-border rounded hover:text-f-danger hover:border-f-danger transition-colors"
+          >
+            초기화
+          </button>
+        )}
+
+        {isFiltered && (
+          <span className="ml-auto text-[11px] text-f-t4 tabular-nums font-mono">
+            <span className="text-f-t2 font-semibold">{filteredCases.length}</span>
+            {' '}/ {cases.length}
+          </span>
+        )}
       </div>
 
+      {/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+          리치 리스트 — 각 행 80px, 타이포 계층화
+          ① 좌측: 시퀀스 인덱스 (모노 / 희미)
+          ② 가운데: 큰 제목(16px) + 메타 chip row
+          ③ 우측: 날짜 + 삭제 버튼
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */}
       <div className="flex-1 overflow-auto">
-        <table className="w-full border-collapse text-left">
-          <thead>
-            <tr className="bg-f-surface border-b border-f-border sticky top-0 z-10">
-              {['케이스 ID', '제목', '용량', '분석관', '생성일', ''].map((h, i) => (
-                <th
-                  key={i}
-                  className="h-[34px] px-3.5 text-[10px] font-semibold text-f-t4 tracking-wider uppercase whitespace-nowrap"
-                  style={{ width: i === 0 ? 148 : i === 2 ? 90 : i === 3 ? 88 : i === 4 ? 100 : i === 5 ? 44 : 'auto' }}
-                >
-                  {h}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {filteredCases.length === 0 ? (
-              <tr>
-                <td colSpan={6} className="py-9 px-3.5 text-center text-sm text-f-t4">
-                  검색·필터 조건에 맞는 케이스가 없습니다.
-                </td>
-              </tr>
-            ) : (
-              filteredCases.map(c => (
-                <tr
-                  key={c.id}
+        {filteredCases.length === 0 ? (
+          /* ── 빈 상태 ── */
+          <div className="flex flex-col items-center justify-center h-full gap-3 py-16 text-f-t4">
+            <FolderOpen size={40} strokeWidth={1.2} />
+            <p className="text-[13px]">
+              {caseSearchQuery || caseAnalystFilter !== 'all'
+                ? '검색·필터 조건에 맞는 케이스가 없습니다.'
+                : '케이스가 없습니다.'}
+            </p>
+          </div>
+        ) : (
+          <ul role="list" className="divide-y divide-f-border">
+            {filteredCases.map((c, idx) => (
+              <li key={c.id}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`케이스 ${c.id} ${c.title} 열기`}
                   onClick={() => onRowClick({ id: c.id, title: c.title })}
-                  className="h-12 border-b border-f-border cursor-pointer bg-f-surface hover:bg-f-surface2 transition-colors"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onRowClick({ id: c.id, title: c.title });
+                    }
+                  }}
+                  className="group flex items-center gap-5 px-6 h-16 cursor-pointer bg-f-surface hover:bg-f-surface2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-f-accent focus-visible:ring-inset"
                 >
-                  <td className="px-3.5 font-mono text-[11px] text-f-accent font-medium">{c.id}</td>
-                  <td className="px-3.5 text-[13px] text-f-t1 max-w-xs overflow-hidden text-ellipsis whitespace-nowrap">{c.title}</td>
-                  <td className="px-3.5 text-xs text-f-t4">{c.size}</td>
-                  <td className="px-3.5 text-xs text-f-t3">{c.analyst}</td>
-                  <td className="px-3.5 text-xs text-f-t4">{c.date}</td>
-                  <td className="px-2">
+                  {/* ① 시퀀스 번호 */}
+                  <span
+                    className="w-8 text-right text-[11px] font-mono text-f-t4 tabular-nums shrink-0 group-hover:text-f-t3 transition-colors select-none"
+                    aria-hidden
+                  >
+                    {String(idx + 1).padStart(2, '0')}
+                  </span>
+
+                  {/* ② 메인 콘텐츠 — 제목 + 메타 chip row */}
+                  <div className="flex-1 min-w-0">
+                    {/* 제목 */}
+                    <p className="text-[15px] font-semibold text-f-t1 leading-snug truncate mb-1.5 group-hover:text-f-accent transition-colors">
+                      {c.title}
+                    </p>
+
+                    {/* 메타 chip row */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {/* ID chip */}
+                      <span className="inline-flex items-center h-5 px-2 rounded bg-f-surface2 border border-f-border text-[10px] font-mono text-f-t3 tracking-wide group-hover:border-f-border2 transition-colors">
+                        {c.id}
+                      </span>
+
+                      <span className="w-px h-3 bg-f-border" aria-hidden />
+
+                      {/* 분석관 */}
+                      <span className="text-[11px] text-f-t3 font-medium">
+                        {c.analyst}
+                      </span>
+
+                      <span className="w-px h-3 bg-f-border" aria-hidden />
+
+                      {/* 용량 */}
+                      <span className="text-[11px] text-f-t4 font-mono tabular-nums">
+                        {c.size}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* ③ 우측: 날짜 + 삭제 */}
+                  <div className="flex items-center gap-4 shrink-0">
+                    {/* 날짜 — 2줄 표현 */}
+                    <div className="text-right hidden sm:block">
+                      <p className="text-[10px] text-f-t4 tracking-[0.08em] uppercase mb-0.5">
+                        생성일
+                      </p>
+                      <p className="text-[12px] font-mono tabular-nums text-f-t3">
+                        {c.date}
+                      </p>
+                    </div>
+
+                    {/* 삭제 버튼 */}
                     <button
-                      onClick={e => { e.stopPropagation(); onDelete(c.id); }}
-                      className="w-7 h-7 border-none bg-transparent rounded-[5px] flex items-center justify-center cursor-pointer text-f-t4 hover:text-f-danger hover:bg-red-50 transition-colors"
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(c.id);
+                      }}
+                      aria-label={`${c.id} 삭제`}
+                      tabIndex={0}
+                      className="w-8 h-8 rounded-md flex items-center justify-center border border-transparent text-f-t4 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-f-danger hover:bg-f-surface hover:border-f-border transition-all shrink-0"
                     >
-                      <Trash2 size={13} />
+                      <Trash2 size={14} />
                     </button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/hooks/useCases.ts
+++ b/src/hooks/useCases.ts
@@ -6,11 +6,9 @@ function coerceCase(raw: Record<string, unknown>): Case {
   return {
     id: String(raw.id ?? ''),
     title: String(raw.title ?? raw.name ?? ''),
-    status: (raw.status as Case['status']) ?? 'idle',
     analyst: String(raw.analyst ?? '-'),
     size: String(raw.size ?? '-'),
     date: String(raw.date ?? new Date().toISOString().slice(0, 10)),
-    progress: typeof raw.progress === 'number' ? raw.progress : 0,
   };
 }
 

--- a/src/mocks/data/cases.ts
+++ b/src/mocks/data/cases.ts
@@ -1,8 +1,8 @@
 import type { Case } from '@/types';
 
 export const MOCK_CASES: Case[] = [
-  { id: 'DF-2026-0425', title: '20260425_김영끌_랜섬웨어', status: 'running', analyst: '김영끌', size: '50GB', date: '2026-04-25', progress: 45 },
-  { id: 'DF-2023-0820', title: 'USB 저장매체 삭제파일 복구', status: 'done', analyst: '이포렌', size: '2.3GB', date: '2023-08-20', progress: 100 },
-  { id: 'DF-2023-0901', title: '이메일 피싱 계정 추적', status: 'idle', analyst: '박디지', size: '1.2GB', date: '2023-09-01', progress: 0 },
-  { id: 'DF-2023-0910', title: '사내 기밀 유출 타임라인 분석', status: 'failed', analyst: '김수사', size: '256GB', date: '2023-09-10', progress: 12 },
+  { id: 'DF-2026-0425', title: '20260425_김영끌_랜섬웨어', analyst: '김영끌', size: '50GB', date: '2026-04-25' },
+  { id: 'DF-2023-0820', title: 'USB 저장매체 삭제파일 복구', analyst: '이포렌', size: '2.3GB', date: '2023-08-20' },
+  { id: 'DF-2023-0901', title: '이메일 피싱 계정 추적', analyst: '박디지', size: '1.2GB', date: '2023-09-01' },
+  { id: 'DF-2023-0910', title: '사내 기밀 유출 타임라인 분석', analyst: '김수사', size: '256GB', date: '2023-09-10' },
 ];

--- a/src/mocks/handlers/rest.ts
+++ b/src/mocks/handlers/rest.ts
@@ -23,13 +23,11 @@ export const restHandlers = [
     const created = {
       id,
       title: body.name ?? '새 케이스',
-      status: 'idle',
       analyst: '-',
       size: '-',
       date: new Date().toISOString().slice(0, 10),
-      progress: 0,
     };
-    MOCK_CASES.unshift(created as any);
+    MOCK_CASES.unshift(created);
     return HttpResponse.json(created);
   }),
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,17 +13,14 @@ export type WorkflowState =
   | 'done';
 
 export type ReportState = 'idle' | 'generating' | 'done';
-export type CaseStatus = 'running' | 'done' | 'idle' | 'failed';
 export type CaseSort = 'dateDesc' | 'dateAsc' | 'titleAsc';
 
 export interface Case {
   id: string;
   title: string;
-  status: CaseStatus;
   analyst: string;
   size: string;
   date: string;
-  progress: number;
 }
 
 export interface ActiveCase {


### PR DESCRIPTION
## Summary
- 케이스 목록 상단을 히어로 스탯바(케이스 수 · 분석관 · 최근 갱신 · 총 용량)로 재구성하고 검색 인풋을 헤더로 승격
- 필터 툴바를 얇은 띠로 분리, 초기화 버튼·필터 카운트 추가, 리스트는 시퀀스 인덱스·제목·메타 chip·삭제 액션 구성의 카드형 리스트로 전환 (빈 상태·키보드 접근성 보강)
- `Case` 타입에서 미사용 `status`/`progress` 필드 제거 및 mock·MSW 핸들러·`useCases` 동기화

Closes #17

## Test plan
- [ ] 케이스 목록 진입 시 히어로 스탯바에 전체 케이스 수, 분석관 수, 최근 갱신일, 총 용량이 정상 표시되는지 확인
- [ ] 검색어 입력 시 ID·제목·분석관·용량 매칭 동작 및 카운트(`n / total`) 갱신 확인
- [ ] 분석관/정렬 드롭다운 토글·외부 클릭 닫힘·초기화 버튼 동작 확인
- [ ] 리스트 행 클릭·Enter·Space로 케이스 진입, 삭제 버튼은 행 호버/포커스 시 노출되는지 확인
- [ ] 빈 상태(필터 미일치, 케이스 0건) 메시지 정상 노출 확인
- [ ] `useCases`/MSW 응답이 status·progress 제거 이후에도 정상 매핑되는지 확인